### PR TITLE
Fix html generation

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,10 @@
 FROM ayberkt/agda-new:v2.1
 
 COPY entrypoint.sh /entrypoint.sh
+COPY get_pandoc.sh /get_pandoc.sh
+
+RUN ["chmod", "+x", "/get_pandoc.sh"]
+RUN ["./get_pandoc.sh"]
 
 RUN ["chmod", "+x", "/entrypoint.sh"]
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -40,7 +40,14 @@ if [ "$4" == "true" ]; then
     # Generate HTML from Markdown files.
     cd html
     for file in `ls *.md`; do
-        pandoc --css Agda.css -o $(basename -s .md $file).html $file;
+        title=$(basename -s .md $file)
+        pandoc \
+            --embed-resources \
+            --standalone \
+            --css=Agda.css \
+            --metadata title=$title \
+            -o $title.html \
+            $file;
     done
     cd ..
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -48,6 +48,7 @@ if [ "$4" == "true" ]; then
             --metadata title=$title \
             -o $title.html \
             $file;
+        rm $file
     done
     cd ..
 fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -35,7 +35,7 @@ fi
 
 if [ "$4" == "true" ]; then
     echo "Generating HTML from Agda code."
-    agda --html --html-highlight=code $1
+    agda --html --html-highlight=auto $1
 
     # Generate HTML from Markdown files.
     cd html

--- a/get_pandoc.sh
+++ b/get_pandoc.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+curl -s https://api.github.com/repos/jgm/pandoc/releases/latest \
+| grep "browser_download_url.*amd64.deb" \
+| cut -d : -f 2,3 \
+| tr -d \" \
+| wget -qi -
+dpkg -i *amd64.deb


### PR DESCRIPTION
Fixed a few issues related to generating html:

* Changed to use `--html-highlight=auto`: this means that any `.agda` or `.lagda` files are converted normally to `.html` whereas `.lagda.md` files are correctly converted to `.md`
* Pandoc was not installed in the docker image so conversions of markdown to html was failing (see e.g. https://github.com/tnttodda/TypeTopology/actions/runs/5548570338/jobs/10131691560). I added a script to pull the latest pandoc release.
* Once the markdown files are converted to html, the original generated markdown files are redundant, so I added a line to delete them. This enables a minimal `html` directory to be served somewhere (as in https://github.com/tnttodda/TypeTopology/tree/html)