### PR TITLE
Make it easier to use custom styles

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,33 +1,39 @@
 # action.yml
-name: 'Agda GitHub action'
-description: 'GitHub action for typechecking your Agda code'
+name: "Agda GitHub action"
+description: "GitHub action for typechecking your Agda code"
 inputs:
   main-file:
-    description: 'Main file of the Agda development'
+    description: "Main file of the Agda development"
     required: true
-    default: 'Main.agda'
+    default: "Main.agda"
   source-dir:
-    description: 'The name of the directory where your code lives'
+    description: "The name of the directory where your code lives"
     required: true
     default: src
   unsafe:
-    description: 'Do not use the --safe flag'
+    description: "Do not use the --safe flag"
     required: false
     default: false
   html:
-    description: 'Whether to generate HTML from Agda'
+    description: "Whether to generate HTML from Agda"
     required: false
     default: true
   stdlib:
-    description: 'Whether to make a copy of the standard library'
+    description: "Whether to make a copy of the standard library"
     required: false
     default: false
+  css:
+    description: "Location of custom CSS to use"
+    required: false
+    default: Agda.css
+
 runs:
-  using: 'docker'
-  image: 'Dockerfile'
+  using: "docker"
+  image: "Dockerfile"
   args:
     - ${{ inputs.main-file  }}
     - ${{ inputs.source-dir }}
     - ${{ inputs.unsafe     }}
     - ${{ inputs.html       }}
     - ${{ inputs.stdlib     }}
+    - ${{ inputs.css     }}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,24 @@
 #!/bin/bash
 
-echo "Main file: $1"
-echo "Source directory: $2"
-echo "HTML: $4"
+main_file=$1
+source_dir=$2
+unsafe=$3
+generate_html=$4
+standard_library=$5
+css_link=$6
+
+echo "Main file: $main_file"
+echo "Source directory: $source_dir"
+echo "HTML: $generate_html"
+echo "CSS: $css_link"
+
 agda --version
 ghc --version
 cabal --version
 
-cd $2
+cd $source_dir
 
-if [ "$5" == true ]; then
+if [ "$standard_library" == true ]; then
     echo "Setting up the standard library"
 
     # Pull and install the standard library.
@@ -25,17 +34,21 @@ else
   echo "Not setting up the standard library."
 fi
 
-if [ "$3" = "true" ]; then
+if [ "$unsafe" = "true" ]; then
     echo "Running Agda in unsafe mode."
-    agda $1 || exit 1
+    agda $main_file || exit 1
 else
     echo "Running Agda in safe mode."
-    agda --safe $1 || exit
+    agda --safe $main_file || exit
 fi
 
-if [ "$4" == "true" ]; then
+if [ "$generate_html" == "true" ]; then
     echo "Generating HTML from Agda code."
-    agda --html --html-highlight=auto $1
+    if [ "$css_link" == "Agda.css" ]; then
+        agda --html --html-highlight=auto $main_file
+    else
+        agda --html --html-highlight=auto --css=$css_link $main_file
+    fi
 
     # Generate HTML from Markdown files.
     cd html
@@ -43,7 +56,7 @@ if [ "$4" == "true" ]; then
         title=$(basename -s .md $file)
         pandoc \
             --standalone \
-            --css=Agda.css \
+            --css=$css_link \
             --metadata title=$title \
             -o $title.html \
             $file;

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -42,7 +42,6 @@ if [ "$4" == "true" ]; then
     for file in `ls *.md`; do
         title=$(basename -s .md $file)
         pandoc \
-            --embed-resources \
             --standalone \
             --css=Agda.css \
             --metadata title=$title \


### PR DESCRIPTION
Sometimes one might want to use custom styles instead of the default Agda one, so this adds an option to do so.

(This also fixes a 'bug' introduced in my previous PR which embedded all the CSS inline rather than as a `link`).